### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM python:3.11-slim
+
+# Set work directory
+WORKDIR /app
+
+# Install dependencies
+# Copy pyproject and requirement files first for caching
+COPY pyproject.toml requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY . .
+
+# Install the package
+RUN pip install --no-cache-dir .
+
+# Expose port
+EXPOSE 8000
+
+# Default command
+CMD ["uvicorn", "capsule_mcp.server:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -295,6 +295,23 @@ curl -X POST https://your-service.onrender.com/mcp/ \
 
 ---
 
+## Docker Image
+
+Run the MCP server inside a Docker container:
+
+```bash
+# Build the image
+docker build -t capsule-mcp .
+
+# Start the server
+docker run -p 8000:8000 \
+  -e CAPSULE_API_TOKEN=your_capsule_api_token_here \
+  capsule-mcp
+```
+
+Set `MCP_API_KEY` if you need HTTP authentication. The API will be available at http://localhost:8000/mcp/.
+
+
 ## For Developers
 
 ### Development Setup


### PR DESCRIPTION
## Summary
- add a simple Dockerfile to run the MCP server
- document Docker usage in README

## Testing
- `PYENV_VERSION=3.11.12 pip install -e .`
- `PYENV_VERSION=3.11.12 python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6880c166e3a4832e85d97cf84ec659f1